### PR TITLE
fix: refine timer stop accuracy

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -168,8 +168,11 @@ namespace Timer
 
             stopwatchTimer.Stop();
 
-            // 添加到历史记录
+            // 计算最终耗时，避免因最后一次 Tick 未触发导致的时间误差
             var endTime = DateTime.Now;
+            stopwatchElapsed = endTime.Subtract(stopwatchStartTime);
+
+            // 添加到历史记录
             var duration = stopwatchElapsed;
             AddToHistory("计时", stopwatchStartTime, endTime, duration);
 
@@ -358,8 +361,15 @@ namespace Timer
 
             countdownTimer.Stop();
 
-            // 添加到历史记录
+            // 在停止时刷新剩余时间，确保记录的持续时间精确
             var endTime = DateTime.Now;
+            countdownRemaining = countdownEndTime.Subtract(endTime);
+            if (countdownRemaining.TotalSeconds < 0)
+            {
+                countdownRemaining = TimeSpan.Zero;
+            }
+
+            // 添加到历史记录
             var actualDuration = countdownOriginal.Subtract(countdownRemaining);
             AddToHistory("倒计时", countdownStartTime, endTime, actualDuration, "", countdownOriginal);
 


### PR DESCRIPTION
## Summary
- ensure stopwatch captures precise elapsed time when stopping
- refresh countdown remaining time before logging history

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e5a4fda4832b844aa9f169a6787b